### PR TITLE
Typo fix in MakeFile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,5 @@ $(TARGET): $(wildcard src/*.js)
 
 .PHONY: install
 install: $(TARGET)
-	mkdir p ~/.config/mpv/scripts/
+	mkdir -p ~/.config/mpv/scripts/
 	cp $< ~/.config/mpv/scripts/


### PR DESCRIPTION
I guess you just forgot a dash. Now you can e.g. make install twice. 